### PR TITLE
Don't constrain the message size at the GRPC level

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,6 +34,11 @@ import (
 const (
 	consumeEndpoint = "consume"
 	publishEndpoint = "publish"
+
+	// max message sizes are not really something proximo wants to enforce; it is
+	// up to the underlying broker what they are, so we just use some large hard
+	// coded large values here to replace the 4MB default.
+	maxGRPCMessageSize = 1024 * 1024 * 128
 )
 
 func main() {
@@ -245,7 +250,10 @@ func listenAndServe(sourceFactory proximo.AsyncSourceFactory, sinkFactory proxim
 			grpc_prometheus.StreamServerInterceptor,
 			grpc_recovery.StreamServerInterceptor(),
 		),
+		grpc.MaxRecvMsgSize(maxGRPCMessageSize),
+		grpc.MaxSendMsgSize(maxGRPCMessageSize),
 	}
+
 	grpcServer := grpc.NewServer(opts...)
 	defer grpcServer.Stop()
 	healthSrv := health.NewServer()


### PR DESCRIPTION
Max message size (if there is one) is a concern of the underlying
broker, so we don't really want a max value at the GRPC level, we want
to delegate it to the broker.  Achieve this here by using large hard
coded values for the GRPC max message size.

There's a question about whether we might want to have a single "max
size" config option that we use for configuring both the broker client
and grpc settings, but not all broker clients have this ability, and its
not clear what benefit that would have anyway.